### PR TITLE
DEVOPS-70 Backup procedure of GOCDB.

### DIFF
--- a/gocdb_backup/LICENSE
+++ b/gocdb_backup/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/gocdb_backup/README.md
+++ b/gocdb_backup/README.md
@@ -1,0 +1,58 @@
+GOCDB Backup.
+=============
+
+This bash script is intended to create a tarball with all necessary files so that we have a complete backup for the **GOCDB** project.
+
+## Requirements.
+This bash script is very simple, but it is required to have the **mysql** tool installed.
+
+### Installation of mysql.
+* Debian GNU/Linux.
+```bash
+apt install mysql-client
+``` 
+
+* CentOS Linux.
+```bash
+yum install mysql
+```
+
+
+Usage.
+======
+
+## Command Line Options
+
+The following is the output from `./gocdbBackup.sh -help`, providing an overview of the basic command line options:
+
+```
+GOCDB Backup.
+------------------------------------------------------------------------------------------ 
+gocdbBackup.sh [arguments]
+ 
+Arguments:
+--help  Show brief help.
+-u  Database username - Specify the username that has rights in the database you want to back up.
+-p  Database password - Specify the database user password.
+-d  Database name     - Specify the name of the database for which you want to back up.
+------------------------------------------------------------------------------------------ 
+Usage: ./gocdbBackup.sh -u user -p 'password' -d database
+```
+
+## Examples.
+
+```bash
+./gocdbBackup.sh -u 'gocdb_db_username' -p '!4@$6' -d 'gocdbDatabase'
+```
+
+```bash
+/var/backups/
+└── gocdb
+    ├── archives
+    │   └── 2020-05-21_gocdb_demo.tar.gz
+    ├── database
+    │   └── 2020-05-21_gocdb_demo_gocdbDatabase.sql
+    └── site
+        └── 2020-05-21_gocdb_demo_gocdbFiles_sha256sum
+```
+

--- a/gocdb_backup/gocdbBackup.sh
+++ b/gocdb_backup/gocdbBackup.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+#########################################################################################
+# GOCDB Backup - A simple script that compresses all the necessary files needed for
+# a complete backup.
+#
+# Copyright (C) 2020 GRNET.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# Along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.   
+#
+# Contributor(s):
+#	* Anastasios Lisgaras <tasos@admin.grnet.gr>
+#########################################################################################
+
+set -u
+set -f
+set -o pipefail
+
+while getopts h:u:p:d: option 
+do
+	case "${option}" in
+	h|--help)
+		echo -e "GOCDB Backup."
+		echo -e "------------------------------------------------------------------------------------------ "
+		echo -e "gocdbBackup.sh [arguments]"
+		echo -e " "
+		echo -e "Arguments:"
+		echo -e "--help \tShow brief help."
+		echo -e "-u \tDatabase username - Specify the username that has rights in the database you want to back up."
+		echo -e "-p \tDatabase password - Specify the database user password."
+		echo -e "-d \tDatabase name\t  - Specify the name of the database for which you want to back up."
+		echo -e "------------------------------------------------------------------------------------------ "
+		echo -e "Usage: ./gocdbBackup.sh -u user -p 'password' -d database"
+		exit 0
+		;;
+	u) DATABASE_USER=${OPTARG} ;;
+	p) DATABASE_PASSWORD=${OPTARG} ;;
+	d) DATABASE_NAME=${OPTARG} ;;
+	esac
+done
+
+
+timestamp=$(date +%Y-%m-%d)
+web_server_conf_files="/etc/httpd/"
+web_server_log_files="/var/log/httpd/"
+gocdb_files="/var/backups/gocdb/site"
+database_dumps="/var/backups/gocdb/database"
+archives="/var/backups/gocdb/archives"
+
+
+## Create directories if doesn't exist.
+[ ! -d $gocdb_files		] && mkdir -p ${gocdb_files}
+[ ! -d $database_dumps	] && mkdir -p ${database_dumps}
+[ ! -d $archives		] && mkdir -p ${archives}
+
+
+# Backup files 
+## SQL.
+mysqldumb="/usr/bin/mysqldump --user='$DATABASE_USER'  --password='$DATABASE_PASSWORD'  --lock-tables --databases ${DATABASE_NAME} > ${database_dumps}/${timestamp}_${HOSTNAME}_${DATABASE_NAME}.sql"
+eval "$mysqldumb"
+
+
+## Server files.
+find /var/www/gocdb/ -type f -exec sha256sum {} + > ${gocdb_files}/${timestamp}_${HOSTNAME}_gocdbFiles_sha256sum
+
+
+# Archive
+cp ${gocdb_files}/${timestamp}_${HOSTNAME}_gocdbFiles_sha256sum ${database_dumps}
+
+## Archive the hashing file of gocdb files, web server configuration files, web server logs and database.
+cd ${database_dumps} && \
+tar -zcvf ${archives}/${timestamp}_${HOSTNAME}.tar.gz \
+	${timestamp}_${HOSTNAME}_${DATABASE_NAME}.sql \
+	${timestamp}_${HOSTNAME}_gocdbFiles_sha256sum \
+	${web_server_conf_files} \
+	${web_server_log_files}
+
+rm ${database_dumps}/${timestamp}_${HOSTNAME}_gocdbFiles_sha256sum
+
+# Delete old files
+find /var/backups/gocdb/* -mtime +14 -exec rm {} \;
+find /var/backups/gocdb/* -type d -empty -delete
+
+
+
+
+# vim: syntax=sh ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
Bash script that is responsible for packaging in a tarball whatever is necessary so that we have a complete backup of the [**GOCDB**](https://github.com/tas-sos/gocdb) project.

In this version we keep a backup copy of the following:

- [ ] Database.
- [ ] Hashing map from all gocdb files.
- [ ] Apache configuration files.
- [ ] Apache log files.